### PR TITLE
fix piggybanks_dfs

### DIFF
--- a/src/cw9/zad1/piggybanks_dfs.cpp
+++ b/src/cw9/zad1/piggybanks_dfs.cpp
@@ -22,7 +22,7 @@ int piggybanks_dfs(std::vector<int> piggybanks) {
                 cycles[next_pig] = i;
                 next_pig = piggybanks[next_pig];
             }
-            if (next_pig == i) closed_cycles_count++;
+            if (cycles[next_pig] == i) closed_cycles_count++;
         }
     }
 


### PR DESCRIPTION
Chyba znalazłem bug w kodzie, przykładowo dla wejścia `{1,2,1}` dawało wynik 0 a powinno być 1.

Jak testowałem to dla przypadków które wymyśliłem teraz wszystko działa więc powinno być git.